### PR TITLE
Cloud Concierge Report - 2023-07-27-18-56

### DIFF
--- a/terraform/persistent-storage/cloud-concierge/imports/2023-07-27-18-56_imports.tf
+++ b/terraform/persistent-storage/cloud-concierge/imports/2023-07-27-18-56_imports.tf
@@ -1,0 +1,8 @@
+import {
+  to = "aws_db_instance.created-outside-of-terraform-workflow"
+  id = "created-outside-of-terraform-workflow"
+}
+import {
+  to = "aws_db_subnet_group.default-vpc-0e011b4a5a571b7e6"
+  id = "default-vpc-0e011b4a5a571b7e6"
+}

--- a/terraform/persistent-storage/new-resources.tf
+++ b/terraform/persistent-storage/new-resources.tf
@@ -1,0 +1,61 @@
+# Identified Resource Cost Components:
+## Database instance (on-demand, Single-AZ, db.t3.micro)
+###### Monthly Cost: $13.14
+###### Price / Unit: $0.018 / hours
+## Storage (general purpose SSD, gp2)
+###### Monthly Cost: $2.3
+###### Price / Unit: $0.115 / GB
+## Additional backup storage
+###### Monthly Cost: $0
+###### Price / Unit: $0.095 / GB
+## Performance Insights API
+###### Monthly Cost: $0
+###### Price / Unit: $0.01 / 1000 requests
+
+# Created at 2023-07-26 by root
+resource "aws_db_instance" "created_outside_of_terraform_workflow" {
+  allocated_storage                     = "20"
+  auto_minor_version_upgrade            = "true"
+  availability_zone                     = "us-east-1c"
+  backup_retention_period               = "1"
+  backup_window                         = "03:36-04:06"
+  ca_cert_identifier                    = "rds-ca-2019"
+  copy_tags_to_snapshot                 = "true"
+  customer_owned_ip_enabled             = "false"
+  db_subnet_group_name                  = "${aws_db_subnet_group.tfer--default-vpc-0e011b4a5a571b7e6.name}"
+  deletion_protection                   = "false"
+  engine                                = "postgres"
+  engine_version                        = "15.3"
+  iam_database_authentication_enabled   = "false"
+  identifier                            = "created-outside-of-terraform-workflow"
+  instance_class                        = "db.t3.micro"
+  iops                                  = "0"
+  kms_key_id                            = "arn:aws:kms:us-east-1:682649898103:key/294a43e5-9c30-4e21-a497-c1cce3a1967d"
+  license_model                         = "postgresql-license"
+  maintenance_window                    = "sun:04:57-sun:05:27"
+  max_allocated_storage                 = "1000"
+  monitoring_interval                   = "0"
+  multi_az                              = "false"
+  network_type                          = "IPV4"
+  option_group_name                     = "default:postgres-15"
+  parameter_group_name                  = "default.postgres15"
+  performance_insights_enabled          = "true"
+  performance_insights_kms_key_id       = "arn:aws:kms:us-east-1:682649898103:key/294a43e5-9c30-4e21-a497-c1cce3a1967d"
+  performance_insights_retention_period = "7"
+  port                                  = "5432"
+  publicly_accessible                   = "false"
+  storage_encrypted                     = "true"
+  storage_throughput                    = "0"
+  storage_type                          = "gp2"
+  username                              = "postgres"
+  vpc_security_group_ids                = ["sg-04e6321d4531e452e"]
+}
+
+# This resource has no identified cost 
+# Created at 2023-07-26 by root
+resource "aws_db_subnet_group" "default_vpc_0e011b4a5a571b7e6" {
+  description = "Created from the RDS Management Console"
+  name        = "default-vpc-0e011b4a5a571b7e6"
+  subnet_ids  = ["subnet-00529b1ec11eca6b9", "subnet-04b0c0aaf5f2f685f", "subnet-05d40b6a97dfd9e38", "subnet-091751b8f2e250fb2", "subnet-0b71dcbc4c9769554", "subnet-0f7844a34bc5ac55b"]
+}
+


### PR DESCRIPTION
Cloud Concierge Report - State of Scanned Cloud Resources
=========================================================

Contents
========

* [How to Read this Report](#how-to-read-this-report)
* [Identified Security Risks](#identified-security-risks)
* [Calculable Cloud Costs (Monthly)](#calculable-cloud-costs-monthly)
* [Resources Outside of Terraform Control](#resources-outside-of-terraform-control)
* [Drifted Resources Managed By Terraform](#drifted-resources-managed-by-terraform)
* [Root Causes of Drift](#root-causes-of-drift)

# How to Read this Report
  
Your job, titled Cloud Concierge Report, has run. Of the resources the job scans, at least one resource was identified to have drifted or be outside of Terraform control. While code has been generated of the Terraform code and corresponding import statements needed to bring these resources under Terraform control, below you will find a summary of the gaps identified in your current IaC posture.
# Identified Security Risks

## Division `dragondrop-dev`
  
**Instance ID**: `arn:aws:elasticloadbalancing:us-east-1:682649898103:loadbalancer/app/tf-managed-demo-alb/4c89e21113613302`
|Rule Description|Severity|Resolution|Doc Links|
| :---: | :---: | :---: | :---: |
|Load balancer is exposed to the internet.|HIGH    |Switch to an internal load balancer or add a tfsec ignore|[Rule](https://aquasecurity.github.io/tfsec/v1.28.1/checks/aws/elb/alb-not-public/), [Tf Doc](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/lb)|
|Load balancers should drop invalid headers|HIGH    |Set drop_invalid_header_fields to true|[Rule](https://aquasecurity.github.io/tfsec/v1.28.1/checks/aws/elb/drop-invalid-headers/), [Tf Doc](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/lb#drop_invalid_header_fields)|
  
**Instance ID**: `arn:aws:rds:us-east-1:682649898103:db:created-outside-of-terraform-workflow`
|Rule Description|Severity|Resolution|Doc Links|
| :---: | :---: | :---: | :---: |
|RDS Deletion Protection Disabled|MEDIUM  |Modify the RDS instances to enable deletion protection.|[Rule](https://aquasecurity.github.io/tfsec/v1.28.1/checks/aws/rds/enable-deletion-protection/)|
|RDS IAM Database Authentication Disabled|MEDIUM  |Modify the PostgreSQL and MySQL type RDS instances to enable IAM database authentication.|[Rule](https://aquasecurity.github.io/tfsec/v1.28.1/checks/aws/rds/enable-iam-auth/)|
|RDS Cluster and RDS instance should have backup retention longer than default 1 day|MEDIUM  |Explicitly set the retention period to greater than the default|[Rule](https://aquasecurity.github.io/tfsec/v1.28.1/checks/aws/rds/specify-backup-retention/), [Tf Doc](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/rds_cluster#backup_retention_period)|

# Calculable Cloud Costs (Monthly)

|Cloud Provider|Uncontrolled Resources Cost|Terraform Controlled Resources Cost|
| :---: | :---: | :---: |
|aws|$15.44|$16.42|

# Resources Outside of Terraform Control

|Provider|# Resources|
| :---: | :---: |
|aws|2|

## AWS
  

|Division|# Resources|
| :---: | :---: |
|aws-dragondrop-dev|2|
  

|Type|# Resources|Cost Components|Monthly Cost|Usage Based*|
| :---: | :---: | :---: | :---: | :---: |
|aws_db_instance|1|4|$15.44|False|
|aws_db_subnet_group|1|No Charge|No Charge|No Charge|

# Drifted Resources Managed By Terraform

## State File `aws-networking-dev`

### Resource: root (module) "aws_lb" "example_lb"
  
**Instance ID**: `arn:aws:elasticloadbalancing:us-east-1:682649898103:loadbalancer/app/tf-managed-demo-alb/4c89e21113613302`  
  
**Most Recent Non-Terraform Actor**: `root`  
**Most Recent Action Date**: `2023-07-21`  
  
- [ ] Completed  

|Attribute|Terraform Value|Cloud Value|
| :---: | :---: | :---: |
|enable_tls_version_and_cipher_suite_headers|false|true|

# Root Causes of Drift

## Cloud Actors Causing Changes

|Cloud Provider|Division|Actor|Action|Count|
| :---: | :---: | :---: | :---: | :---: |
|aws|dragondrop-dev|root|Create Resource|2|
|aws|dragondrop-dev|root|Modify Resource|1|

#### Disclaimer
  
*Indicates that a resource's cost is usage based. Since we currently do not infer/have knowledge of usage, costs may be material although indicated as 0 here.  
  
This report presents information on the state of your cloud at a point in time and as best Cloud Concierge is able to determine. Cloud Concierge does not currently scan every cloud resource for every  cloud provider. For a list of supported resources, please see our [documentation](https://www.docs.dragondrop.cloud/).  
  
Created by Cloud Concierge at 18:56 UTC on 2023-07-27